### PR TITLE
Redesign homepage hero section

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -124,13 +124,6 @@ export default async function Home({
 
   return (
     <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start text-primary">
-      <link
-        rel="preload"
-        as="image"
-        href="/images/hero/Image.jpg"
-        imageSrcSet="/images/hero/Image.jpg 700w"
-        imageSizes="(min-width: 1024px) 50vw, 100vw"
-      />
       {/* Organization JSON-LD */}
       <Script
         id="ld-org"
@@ -161,17 +154,13 @@ export default async function Home({
       />
 
       <Hero
-        image="/images/hero/Image.jpg"
-        heading="Snag your style in a flash"
-        paragraph="Buy, sell, and discover pre-loved gems from the trendiest brands."
+        heading="Modern marketplace platform without limits"
+        paragraph="Open source marketplace platform built to avoid vendor lock. Modern tech, unlimited customization, no transaction fee."
         buttons={[
-          { label: "Buy now", path: "/categories" },
+          { label: "Schedule a demo", path: "#" },
           {
-            label: "Sell now",
-            path:
-              process.env.NEXT_PUBLIC_ALGOLIA_ID === "UO3C5Y8NHX"
-                ? "https://vendor-sandbox.vercel.app/"
-                : "https://vendor.mercurjs.com",
+            label: "Visit GitHub",
+            path: "https://github.com/mercurjs/mercur",
           },
         ]}
       />

--- a/storefront/src/components/sections/Hero/Hero.stories.tsx
+++ b/storefront/src/components/sections/Hero/Hero.stories.tsx
@@ -12,12 +12,12 @@ type Story = StoryObj<typeof Hero>
 
 export const FirstStory: Story = {
   args: {
-    heading: "Snag your style in a flash",
-    paragraph: "Buy, sell, and discover pre-loved from the trendiest brands.",
-    image: "/images/hero/Image.jpg",
+    heading: "Modern marketplace platform without limits",
+    paragraph:
+      "Open source marketplace platform built to avoid vendor lock. Modern tech, unlimited customization, no transaction fee.",
     buttons: [
-      { label: "Buy now", path: "#" },
-      { label: "Sell now", path: "3" },
+      { label: "Schedule a demo", path: "#" },
+      { label: "Visit GitHub", path: "#" },
     ],
   },
 }

--- a/storefront/src/components/sections/Hero/Hero.tsx
+++ b/storefront/src/components/sections/Hero/Hero.tsx
@@ -1,58 +1,40 @@
-import Image from "next/image"
-
-import tailwindConfig from "../../../../tailwind.config"
-import { ArrowRightIcon } from "@/icons"
 import Link from "next/link"
 
 type HeroProps = {
-  image: string
   heading: string
   paragraph: string
   buttons: { label: string; path: string }[]
 }
 
-export const Hero = ({ image, heading, paragraph, buttons }: HeroProps) => {
+export const Hero = ({ heading, paragraph, buttons }: HeroProps) => {
+  const baseButton = "px-6 py-3 rounded-sm font-medium transition-colors"
+  const primaryButton =
+    "bg-primary text-action hover:bg-action hover:text-tertiary"
+  const secondaryButton =
+    "border border-current text-tertiary hover:bg-primary hover:text-action"
+
   return (
-    <section className="w-full flex container mt-5 flex-col lg:flex-row text-primary">
-      <Image
-        src={decodeURIComponent(image)}
-        width={700}
-        height={600}
-        alt={`Hero banner - ${heading}`}
-        className="w-full order-2 lg:order-1"
-        priority
-        fetchPriority="high"
-        quality={50}
-        sizes="(min-width: 1024px) 50vw, 100vw"
-      />
-      <div className="w-full lg:order-2">
-        <div className="border rounded-sm w-full px-6 flex items-end h-[calc(100%-144px)]">
-          <div>
-            <h2 className="font-bold mb-6 uppercase display-md max-w-[652px] text-4xl md:text-5xl leading-tight">
-              {heading}
-            </h2>
-            <p className="text-lg mb-8">{paragraph}</p>
-          </div>
-        </div>
-        {buttons.length && (
-          <div className="h-[72px] lg:h-[144px] flex font-bold uppercase">
-            {buttons.map(({ label, path }) => (
+    <section className="w-full bg-action py-24 text-tertiary">
+      <div className="container flex flex-col items-center text-center gap-6">
+        <h1 className="text-4xl md:text-6xl font-bold max-w-3xl">
+          {heading}
+        </h1>
+        <p className="text-lg md:text-xl max-w-2xl text-tertiary/80">
+          {paragraph}
+        </p>
+        {buttons.length > 0 && (
+          <div className="flex gap-4 mt-4">
+            {buttons.map(({ label, path }, i) => (
               <Link
                 key={path}
                 href={path}
-                className="group flex border rounded-sm h-full w-1/2 bg-content hover:bg-action hover:text-tertiary transition-all duration-300 p-6 justify-between items-end"
+                className={`${baseButton} ${
+                  i === 0 ? primaryButton : secondaryButton
+                }`}
                 aria-label={label}
                 title={label}
               >
-                <span>
-                  <span className="group-hover:inline-flex hidden">#</span>
-                  {label}
-                </span>
-
-                <ArrowRightIcon
-                  color={tailwindConfig.theme.extend.backgroundColor.primary}
-                  aria-hidden
-                />
+                {label}
               </Link>
             ))}
           </div>
@@ -61,3 +43,4 @@ export const Hero = ({ image, heading, paragraph, buttons }: HeroProps) => {
     </section>
   )
 }
+


### PR DESCRIPTION
## Summary
- Replace image-based hero with centered call-to-action layout
- Update homepage copy to promote demo and GitHub visit
- Adjust storybook story for new hero API

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc05a4aca08331a22525394ac9231a