### PR TITLE
fix: apply 1344px desktop content width

### DIFF
--- a/storefront/src/app/globals.css
+++ b/storefront/src/app/globals.css
@@ -55,7 +55,7 @@
   @apply text-[64px] leading-[72px] font-medium tracking-normal max-md:text-[40px] max-md:leading-[48px];
 }
 .container {
-  @apply px-4 md:px-5 max-w-full w-full lg:py-8 py-4 lg:px-8;
+  @apply px-4 md:px-5 lg:px-8 w-full max-w-[1344px] mx-auto lg:py-8 py-4;
 }
 
 /* Atoms components */

--- a/storefront/src/components/cells/Navbar/Navbar.tsx
+++ b/storefront/src/components/cells/Navbar/Navbar.tsx
@@ -7,7 +7,7 @@ export const Navbar = ({
   categories: HttpTypes.StoreProductCategory[]
 }) => {
   return (
-    <div className="flex border py-4 justify-between px-6">
+    <div className="mx-auto flex w-full max-w-[1344px] border justify-between py-4 px-4 lg:px-8">
       <div className="hidden md:flex items-center">
         <CategoryNavbar categories={categories} />
       </div>

--- a/storefront/src/components/organisms/Header/Header.tsx
+++ b/storefront/src/components/organisms/Header/Header.tsx
@@ -39,7 +39,7 @@ export const Header = async () => {
 
   return (
     <header>
-      <div className="flex py-2 lg:px-8 px-4">
+      <div className="mx-auto flex w-full max-w-[1344px] py-2 px-4 lg:px-8">
         <div className="flex items-center lg:w-1/3">
           <MobileNavbar
             parentCategories={parentCategories}


### PR DESCRIPTION
## Summary
- constrain global container to 1344px
- center header and navigation to match new content width

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc09e874608331a03c61ba8d0eca15