### PR TITLE
feat(storefront): use Poppins font globally

### DIFF
--- a/storefront/src/app/globals.css
+++ b/storefront/src/app/globals.css
@@ -5,6 +5,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  @apply font-sans;
+}
+
 /* Typography */
 .text-xl {
   @apply font-light tracking-normal;

--- a/storefront/src/app/layout.tsx
+++ b/storefront/src/app/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next"
-import { Funnel_Display } from "next/font/google"
+import { Poppins } from "next/font/google"
 import "./globals.css"
 import { Toaster } from "@medusajs/ui"
 import Head from "next/head"
 
-const funnelDisplay = Funnel_Display({
-  variable: "--font-funnel-sans",
+const poppins = Poppins({
   subsets: ["latin"],
   weight: ["300", "400", "500", "600"],
+  variable: "--font-poppins",
 })
 
 export const metadata: Metadata = {
@@ -46,7 +46,7 @@ export default async function RootLayout({
   const htmlLang = locale || "en"
 
   return (
-    <html lang={htmlLang} className="">
+    <html lang={htmlLang} className={poppins.variable}>
       <Head>
         <link
           rel="preconnect"
@@ -114,9 +114,7 @@ export default async function RootLayout({
         />
         <link rel="dns-prefetch" href="https://api.mercurjs.com" />
       </Head>
-      <body
-        className={`${funnelDisplay.className} antialiased bg-primary text-secondary relative`}
-      >
+      <body className="font-sans antialiased bg-primary text-secondary relative">
         {children}
         <Toaster position="top-right" />
       </body>

--- a/storefront/tailwind.config.ts
+++ b/storefront/tailwind.config.ts
@@ -9,6 +9,9 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-poppins)", "sans-serif"],
+      },
       backgroundColor: {
         primary: "rgba(var(--bg-primary))",
         secondary: "rgba(var(--bg-secondary))",


### PR DESCRIPTION
## Summary
- load Poppins from Google Fonts and apply across the storefront
- configure Tailwind to use Poppins as the default sans-serif family
- ensure body applies the sans font class

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc115b1df8833199724039aefb870f