### PR TITLE
feat(frontend): add commerce modules section on home

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -5,6 +5,7 @@ import {
   HomeCategories,
   HomeProductSection,
   ShopByStyleSection,
+  CommerceModulesSection,
 } from "@/components/sections"
 
 import type { Metadata } from "next"
@@ -164,6 +165,7 @@ export default async function Home({
           },
         ]}
       />
+      <CommerceModulesSection />
       <div className="px-4 lg:px-8 w-full">
         <HomeProductSection heading="trending listings" locale={locale} home />
       </div>

--- a/storefront/src/components/sections/CommerceModulesSection/CommerceModulesSection.tsx
+++ b/storefront/src/components/sections/CommerceModulesSection/CommerceModulesSection.tsx
@@ -1,0 +1,97 @@
+import {
+  CurrencyDollar,
+  Puzzle,
+  ServerStack,
+  ShoppingBag,
+  User,
+  CogSixTooth,
+} from "@medusajs/icons"
+
+const moduleIcons = [
+  ServerStack,
+  Puzzle,
+  ShoppingBag,
+  CurrencyDollar,
+  CogSixTooth,
+  User,
+]
+
+const features = [
+  {
+    icon: ShoppingBag,
+    title: "Cart",
+    description: "Add to cart, checkout, and totals",
+  },
+  {
+    icon: CurrencyDollar,
+    title: "Payment",
+    description: "Process any payment type",
+  },
+  {
+    icon: User,
+    title: "Customer",
+    description: "B2C and B2B customer accounts",
+  },
+]
+
+export const CommerceModulesSection = () => {
+  return (
+    <section className="w-full py-20 bg-neutral-50">
+      <div className="container flex flex-col gap-16">
+        <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-8">
+          <div>
+            <p className="uppercase text-sm tracking-widest text-gray-500">
+              Commerce Modules
+            </p>
+            <h2 className="mt-2 text-3xl font-bold">
+              Modules covering all commerce domains
+            </h2>
+          </div>
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6">
+            <div className="flex flex-wrap gap-2">
+              {moduleIcons.map((Icon, i) => (
+                <div
+                  key={i}
+                  className="w-10 h-10 rounded-md bg-white flex items-center justify-center shadow"
+                >
+                  <Icon className="w-6 h-6 text-gray-700" />
+                </div>
+              ))}
+            </div>
+            <p className="text-sm text-gray-600 max-w-xs">
+              Pre-built commerce logic in composable modules. Adopt
+              incrementally, compose as you want.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-8">
+          <div>
+            <p className="uppercase text-sm tracking-widest text-gray-500">
+              Cart &amp; Purchase
+            </p>
+            <h2 className="mt-2 text-3xl font-bold">
+              Checkout, total calculations, and more
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {features.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="flex items-start gap-3 p-4 bg-white rounded-md shadow"
+              >
+                <Icon className="w-6 h-6 text-gray-700" />
+                <div>
+                  <p className="font-semibold">{title}</p>
+                  <p className="text-sm text-gray-600">{description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default CommerceModulesSection

--- a/storefront/src/components/sections/index.ts
+++ b/storefront/src/components/sections/index.ts
@@ -11,6 +11,7 @@ import { WishlistPage } from "./WishlistPage/WishlistPage"
 import { ProductDetailsPage } from "./ProductDetailsPage/ProductDetailsPage"
 import { AlgoliaProductsListing } from "./ProductListing/AlgoliaProductsListing"
 import { OrdersPagination } from "../organisms/OrdersPagination/OrdersPagination"
+import { CommerceModulesSection } from "./CommerceModulesSection/CommerceModulesSection"
 
 export {
   Hero,
@@ -26,4 +27,5 @@ export {
   ProductDetailsPage,
   AlgoliaProductsListing,
   OrdersPagination,
+  CommerceModulesSection,
 }


### PR DESCRIPTION
## Summary
- add CommerceModulesSection component with module icons and cart/purchase cards
- export the new section and render it under the hero on the home page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc18bcfffc8331821818be109f36ee