### PR TITLE
feat: extend home page modules

### DIFF
--- a/storefront/src/components/sections/CommerceModulesSection/CommerceModulesSection.tsx
+++ b/storefront/src/components/sections/CommerceModulesSection/CommerceModulesSection.tsx
@@ -5,6 +5,12 @@ import {
   ShoppingBag,
   User,
   CogSixTooth,
+  Tag,
+  CubeSolid,
+  ShoppingCart,
+  CircleStack,
+  TruckFast,
+  MapPin,
 } from "@medusajs/icons"
 
 const moduleIcons = [
@@ -16,21 +22,74 @@ const moduleIcons = [
   User,
 ]
 
-const features = [
+const sections = [
   {
-    icon: ShoppingBag,
-    title: "Cart",
-    description: "Add to cart, checkout, and totals",
+    label: "Cart & Purchase",
+    heading: "Checkout, total calculations, and more",
+    features: [
+      {
+        icon: ShoppingBag,
+        title: "Cart",
+        description: "Add to cart, checkout, and totals",
+      },
+      {
+        icon: CurrencyDollar,
+        title: "Payment",
+        description: "Process any payment type",
+      },
+      {
+        icon: User,
+        title: "Customer",
+        description: "B2C and B2B customer accounts",
+      },
+    ],
   },
   {
-    icon: CurrencyDollar,
-    title: "Payment",
-    description: "Process any payment type",
+    label: "Merchandising",
+    heading: "Products, pricing, and promotions",
+    features: [
+      {
+        icon: CurrencyDollar,
+        title: "Pricing",
+        description: "Configurable pricing engine",
+      },
+      {
+        icon: Tag,
+        title: "Promotion",
+        description: "Discounts and promotions",
+      },
+      {
+        icon: CubeSolid,
+        title: "Product",
+        description: "Variants, categories, and bulk edits",
+      },
+    ],
   },
   {
-    icon: User,
-    title: "Customer",
-    description: "B2C and B2B customer accounts",
+    label: "Order Management",
+    heading: "OMS, fulfillment, and inventory",
+    features: [
+      {
+        icon: ShoppingCart,
+        title: "Order",
+        description: "Omnichannel order management",
+      },
+      {
+        icon: CircleStack,
+        title: "Inventory",
+        description: "Multi-warehouse and reservations",
+      },
+      {
+        icon: TruckFast,
+        title: "Fulfillment",
+        description: "Order fulfillment and shipping",
+      },
+      {
+        icon: MapPin,
+        title: "Stock Location",
+        description: "Inventory location management",
+      },
+    ],
   },
 ]
 
@@ -65,30 +124,33 @@ export const CommerceModulesSection = () => {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-8">
-          <div>
-            <p className="uppercase text-sm tracking-widest text-gray-500">
-              Cart &amp; Purchase
-            </p>
-            <h2 className="mt-2 text-3xl font-bold">
-              Checkout, total calculations, and more
-            </h2>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {features.map(({ icon: Icon, title, description }) => (
-              <div
-                key={title}
-                className="flex items-start gap-3 p-4 bg-white rounded-md shadow"
-              >
-                <Icon className="w-6 h-6 text-gray-700" />
-                <div>
-                  <p className="font-semibold">{title}</p>
-                  <p className="text-sm text-gray-600">{description}</p>
+        {sections.map(({ label, heading, features }) => (
+          <div
+            key={label}
+            className="grid grid-cols-1 md:grid-cols-2 items-center gap-8"
+          >
+            <div>
+              <p className="uppercase text-sm tracking-widest text-gray-500">
+                {label}
+              </p>
+              <h2 className="mt-2 text-3xl font-bold">{heading}</h2>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {features.map(({ icon: Icon, title, description }) => (
+                <div
+                  key={title}
+                  className="flex items-start gap-3 p-4 bg-white rounded-md shadow"
+                >
+                  <Icon className="w-6 h-6 text-gray-700" />
+                  <div>
+                    <p className="font-semibold">{title}</p>
+                    <p className="text-sm text-gray-600">{description}</p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
+        ))}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- add Merchandising and Order Management sections to CommerceModulesSection

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc1b5e4eec8331ba59d2e4bd18bd58