### PR TITLE
feat: add homepage hero section above trending listings

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -165,10 +165,10 @@ export default async function Home({
           },
         ]}
       />
-      <CommerceModulesSection />
       <div className="px-4 lg:px-8 w-full">
         <HomeProductSection heading="trending listings" locale={locale} home />
       </div>
+      <CommerceModulesSection />
       <div className="px-4 lg:px-8 w-full">
         <HomeCategories heading="SHOP BY CATEGORY" />
       </div>


### PR DESCRIPTION
## Summary
- move hero section above trending listings on storefront home page
- reposition commerce modules section below trending

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc1e1d37508331a4510ecf4794facc