### PR TITLE
feat(storefront): add CTA hero after commerce modules

### DIFF
--- a/storefront/src/app/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[locale]/(main)/page.tsx
@@ -166,6 +166,14 @@ export default async function Home({
         ]}
       />
       <CommerceModulesSection />
+      <Hero
+        heading="Modern marketplace platform without limits"
+        paragraph="Open source marketplace platform built to build or extend tools. Modern tech, unlimited customization, no transaction fee."
+        buttons={[
+          { label: "Schedule demo", path: "#" },
+          { label: "Visit GitHub", path: "https://github.com/mercurjs/mercur" },
+        ]}
+      />
       <div className="px-4 lg:px-8 w-full">
         <HomeProductSection heading="trending listings" locale={locale} home />
       </div>


### PR DESCRIPTION
## Summary
- add call-to-action hero section after "OMS, fulfillment, and inventory"

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc22548a1883318debb80e64f8a9a9