### PR TITLE
feat(storefront): redesign home guide section

### DIFF
--- a/storefront/src/components/sections/ShopByStyle/ShopByStyleSection.tsx
+++ b/storefront/src/components/sections/ShopByStyle/ShopByStyleSection.tsx
@@ -1,62 +1,39 @@
 import Image from "next/image"
 import LocalizedClientLink from "@/components/molecules/LocalizedLink/LocalizedLink"
-import { ArrowRightIcon } from "@/icons"
-import { Style } from "@/types/styles"
-
-export const styles: Style[] = [
-  {
-    id: 1,
-    name: "LUXURY",
-    href: "/collections/luxury",
-  },
-  {
-    id: 2,
-    name: "VINTAGE",
-    href: "/collections/vintage",
-  },
-  {
-    id: 3,
-    name: "CASUAL",
-    href: "/collections/casual",
-  },
-  {
-    id: 4,
-    name: "STREETWEAR",
-    href: "/collections/streetwear",
-  },
-  {
-    id: 5,
-    name: "Y2K",
-    href: "/collections/y2k",
-  },
-]
+import { Button } from "@/components/atoms"
 
 export function ShopByStyleSection() {
   return (
-    <section className="bg-primary container">
-      <h2 className="heading-lg text-primary mb-12">SHOP BY STYLE</h2>
-      <div className="grid grid-cols-1 lg:grid-cols-2 items-center">
-        <div className="py-[52px] px-[58px] h-full border rounded-sm">
-          {styles.map((style) => (
-            <LocalizedClientLink
-              key={style.id}
-              href={style.href}
-              className="group flex items-center gap-4 text-primary hover:text-action transition-colors border-b border-transparent hover:border-primary w-fit pb-2 mb-8"
-            >
-              <span className="heading-lg">{style.name}</span>
-              <ArrowRightIcon className="opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
+    <section className="container bg-primary text-primary">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+        <div className="flex flex-col justify-center h-full py-12">
+          <h2 className="display-sm mb-4">Guide: B2B Food Marketplace</h2>
+          <p className="text-lg text-secondary mb-6 max-w-md">
+            Read how you can build B2B Marketplace with Mercur. Explore the
+            free ebook now.
+          </p>
+          <div className="flex gap-4">
+            <LocalizedClientLink href="#">
+              <Button size="large" className="w-fit">
+                Download Guide
+              </Button>
             </LocalizedClientLink>
-          ))}
+            <LocalizedClientLink href="#">
+              <Button size="large" variant="tonal" className="w-fit">
+                Read online
+              </Button>
+            </LocalizedClientLink>
+          </div>
         </div>
-        <div className="relative hidden lg:block">
+        <div className="relative aspect-[4/3] w-full">
           <Image
             loading="lazy"
             fetchPriority="high"
-            src="/images/shop-by-styles/Image.jpg"
-            alt="Models showcasing luxury fashion styles"
-            width={700}
-            height={600}
-            className="object-cover rounded-sm w-full h-auto"
+            src="/B2C_Storefront_Open_Graph.png"
+            alt="B2B Food Marketplace guide preview"
+            fill
+            className="object-cover rounded-sm"
+            sizes="(min-width: 1024px) 50vw, 100vw"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- redesign Shop By Style section into promotional B2B Food Marketplace guide

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc30df349483319a276ba2e43d03ef