### PR TITLE
Adjust hero heading size and footer logo

### DIFF
--- a/storefront/src/components/organisms/Footer/Footer.tsx
+++ b/storefront/src/components/organisms/Footer/Footer.tsx
@@ -23,9 +23,9 @@ export function Footer() {
             <Image
               src="/Logo.svg"
               alt="Mercur logo"
-              width={32}
-              height={32}
-              className="h-8 w-8"
+              width={135}
+              height={37}
+              className="w-[110px] h-[30px] lg:w-[135px] lg:h-[37px]"
             />
             <span className="text-lg font-medium">Mercur</span>
           </div>

--- a/storefront/src/components/sections/BannerSection/BannerSection.tsx
+++ b/storefront/src/components/sections/BannerSection/BannerSection.tsx
@@ -19,13 +19,6 @@ export const BannerSection = () => {
           />
         </div>
         <div className="flex flex-col justify-center h-full">
-          <Image
-            src="/Logo.png"
-            alt="Notup logo"
-            width={120}
-            height={40}
-            className="mb-4 w-auto h-auto"
-          />
           <h2 className="display-sm mb-4">
             Custom Marketplace built in 9 Weeks
           </h2>

--- a/storefront/src/components/sections/Hero/Hero.tsx
+++ b/storefront/src/components/sections/Hero/Hero.tsx
@@ -16,7 +16,7 @@ export const Hero = ({ heading, paragraph, buttons }: HeroProps) => {
   return (
     <section className="w-full bg-[#20116b] py-32 text-white">
       <div className="container flex flex-col items-center text-center gap-6">
-        <h1 className="text-4xl md:text-6xl font-bold max-w-3xl">
+        <h1 className="text-[2.5rem] font-bold max-w-3xl">
           {heading}
         </h1>
         <p className="text-lg md:text-xl max-w-2xl text-white/80">


### PR DESCRIPTION
## Summary
- set hero heading to 2.5rem font size
- remove Notup logo image from banner section
- match footer logo dimensions to header

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc372bba148331a1001e868204d552