### PR TITLE
feat(storefront): add FAQ section above footer

### DIFF
--- a/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[locale]/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import { Footer, Header } from "@/components/organisms"
+import { FAQSection } from "@/components/sections"
 import { retrieveCustomer } from "@/lib/data/customer"
 import { checkRegion } from "@/lib/helpers/check-region"
 import { Session } from "@talkjs/react"
@@ -26,6 +27,7 @@ export default async function RootLayout({
       <>
         <Header />
         {children}
+        <FAQSection />
         <Footer />
       </>
     )
@@ -35,6 +37,7 @@ export default async function RootLayout({
       <Session appId={APP_ID} userId={user.id}>
         <Header />
         {children}
+        <FAQSection />
         <Footer />
       </Session>
     </>

--- a/storefront/src/components/sections/FAQSection/FAQSection.tsx
+++ b/storefront/src/components/sections/FAQSection/FAQSection.tsx
@@ -1,0 +1,48 @@
+import { Accordion } from "@/components/molecules"
+
+const faqs = [
+  {
+    question: "What makes a commerce platform truly flexible?",
+    answer:
+      "A flexible platform offers modular architecture and open APIs so you can tailor every part of the commerce experience to your business needs.",
+  },
+  {
+    question:
+      "How is a flexible commerce platform more flexible than Shopify Plus, BigCommerce or Adobe Commerce?",
+    answer:
+      "Unlike rigid SaaS solutions, an open and modular setup lets you integrate any service and customize workflows without vendor lock‑in.",
+  },
+  {
+    question: "Can a flexible commerce platform handle enterprise requirements?",
+    answer:
+      "Yes. With proper scaling strategies and extensible tooling, it can meet complex enterprise demands while remaining adaptable.",
+  },
+]
+
+export function FAQSection() {
+  return (
+    <section className="bg-primary">
+      <div className="container py-16">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-2">
+          <div>
+            <p className="label-lg mb-4 uppercase">FAQ</p>
+            <h2 className="heading-lg mb-6 text-primary">
+              Frequently Asked Questions about our flexible commerce platform
+            </h2>
+            <p className="text-secondary">
+              Considering a switch from rigid SaaS platforms? Here&apos;s what technical teams and decision-makers need to know about implementing a truly flexible commerce platform that adapts to your business logic—not the other way around.
+            </p>
+          </div>
+          <div className="flex flex-col gap-4">
+            {faqs.map((faq) => (
+              <Accordion key={faq.question} heading={faq.question} defaultOpen={false}>
+                <p className="text-secondary">{faq.answer}</p>
+              </Accordion>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/storefront/src/components/sections/index.ts
+++ b/storefront/src/components/sections/index.ts
@@ -12,6 +12,7 @@ import { ProductDetailsPage } from "./ProductDetailsPage/ProductDetailsPage"
 import { AlgoliaProductsListing } from "./ProductListing/AlgoliaProductsListing"
 import { OrdersPagination } from "../organisms/OrdersPagination/OrdersPagination"
 import { CommerceModulesSection } from "./CommerceModulesSection/CommerceModulesSection"
+import { FAQSection } from "./FAQSection/FAQSection"
 
 export {
   Hero,
@@ -28,4 +29,5 @@ export {
   AlgoliaProductsListing,
   OrdersPagination,
   CommerceModulesSection,
+  FAQSection,
 }


### PR DESCRIPTION
## Summary
- add reusable FAQ section with accordion entries
- render FAQ section above the footer on main storefront pages

## Testing
- `cd storefront && yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc38615ce88331b9ba5422d33b81d8