### PR TITLE
Add Facebook Pixel tracking to storefront

### DIFF
--- a/storefront/src/app/layout.tsx
+++ b/storefront/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Poppins } from "next/font/google"
 import "./globals.css"
 import { Toaster } from "@medusajs/ui"
 import Head from "next/head"
+import Script from "next/script"
 
 const poppins = Poppins({
   subsets: ["latin"],
@@ -115,6 +116,22 @@ export default async function RootLayout({
         <link rel="dns-prefetch" href="https://api.mercurjs.com" />
       </Head>
       <body className="font-sans antialiased bg-primary text-secondary relative">
+        <Script
+          id="facebook-pixel"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html:
+              "!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init', '578129907772466');fbq('track', 'PageView');",
+          }}
+        />
+        <noscript>
+          <img
+            height="1"
+            width="1"
+            style={{ display: "none" }}
+            src="https://www.facebook.com/tr?id=578129907772466&ev=PageView&noscript=1"
+          />
+        </noscript>
         {children}
         <Toaster position="top-right" />
       </body>


### PR DESCRIPTION
## Summary
- load Meta (Facebook) Pixel script globally in storefront layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc3ab9cb6c83319596d2f6e9d9e192