### PR TITLE
fix: resolve mercur modules via tsconfig paths

### DIFF
--- a/backend/apps/backend/tsconfig.json
+++ b/backend/apps/backend/tsconfig.json
@@ -20,7 +20,9 @@
     "checkJs": false,
     "strictNullChecks": true,
     "paths": {
-      "#/*": ["src/*"]
+      "#/*": ["src/*"],
+      "@mercurjs/framework": ["../../packages/framework"],
+      "@mercurjs/*": ["../../packages/modules/*"]
     }
   },
   "ts-node": {


### PR DESCRIPTION
## Summary
- map `@mercurjs` packages to local workspace modules so Medusa can resolve tenant module

## Testing
- `yarn --cwd backend/apps/backend lint` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bc470065208331b24b3e74d713b8de