### PR TITLE
feat: add tenant routing support

### DIFF
--- a/backend/apps/backend/src/api/middlewares.ts
+++ b/backend/apps/backend/src/api/middlewares.ts
@@ -4,9 +4,14 @@ import { adminMiddlewares } from './admin/middlewares'
 import { hooksMiddlewares } from './hooks/middlewares'
 import { storeMiddlewares } from './store/middlewares'
 import { vendorMiddlewares } from './vendor/middlewares'
+import { resolveTenant } from '../shared/infra/http/middlewares/resolve-tenant'
 
 export default defineMiddlewares({
   routes: [
+    {
+      matcher: /.*/,
+      middlewares: [resolveTenant]
+    },
     ...vendorMiddlewares,
     ...storeMiddlewares,
     ...adminMiddlewares,

--- a/backend/apps/backend/src/shared/infra/http/middlewares/resolve-tenant.ts
+++ b/backend/apps/backend/src/shared/infra/http/middlewares/resolve-tenant.ts
@@ -1,0 +1,48 @@
+import { NextFunction } from 'express'
+import {
+  MedusaRequest,
+  MedusaResponse,
+} from '@medusajs/framework'
+import { TENANT_MODULE, TenantModuleService } from '@mercurjs/tenant'
+import { asValue } from 'awilix'
+
+/**
+ * Resolves the tenant based on the request host and stores it on the request
+ * context so that downstream handlers and services can access it.
+ */
+export async function resolveTenant(
+  req: MedusaRequest,
+  _res: MedusaResponse,
+  next: NextFunction
+) {
+  const host = req.headers.host || ''
+  const hostname = host.split(':')[0]
+  const [slug] = hostname.split('.')
+
+  if (!slug || slug === 'www' || slug === 'localhost') {
+    return next()
+  }
+
+  try {
+    const tenantService = req.scope.resolve<TenantModuleService>(TENANT_MODULE)
+    const [tenant] = await tenantService.listTenants({ slug })
+
+    if (tenant) {
+      ;(req as any).tenant = tenant
+      ;(req as any).tenant_id = tenant.id
+      ;(req as any).tenantId = tenant.id
+
+      if (req.scope && typeof req.scope.register === 'function') {
+        req.scope.register({
+          tenant: asValue(tenant),
+          tenant_id: asValue(tenant.id),
+          tenantId: asValue(tenant.id),
+        })
+      }
+    }
+  } catch (e) {
+    // ignore errors and continue without tenant
+  }
+
+  next()
+}

--- a/storefront/src/app/[tenant]/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[tenant]/[locale]/(main)/layout.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../../../[locale]/(main)/layout'

--- a/storefront/src/app/[tenant]/[locale]/(main)/page.tsx
+++ b/storefront/src/app/[tenant]/[locale]/(main)/page.tsx
@@ -1,0 +1,1 @@
+export { default, generateMetadata } from '../../../../[locale]/(main)/page'


### PR DESCRIPTION
## Summary
- resolve tenant from host and attach to request context
- globally apply tenant resolver middleware
- handle subdomain based tenant routing in storefront

## Testing
- `yarn lint` *(fails: 27 errors, 103 warnings)*
- `yarn lint` (storefront)


------
https://chatgpt.com/codex/tasks/task_e_68bc4b8eb0b8833181c9fac1925bf83c