### PR TITLE
Align vendor auth domain with seller routes

### DIFF
--- a/backend/apps/backend/src/api/vendor/middlewares.ts
+++ b/backend/apps/backend/src/api/vendor/middlewares.ts
@@ -59,7 +59,7 @@ export const vendorMiddlewares: MiddlewareRoute[] = [
     matcher: '/vendor/sellers',
     method: ['POST'],
     middlewares: [
-      authenticate('vendor-admin', ['bearer', 'session'], {
+      authenticate('seller', ['bearer', 'session'], {
         allowUnregistered: true
       })
     ]
@@ -68,7 +68,7 @@ export const vendorMiddlewares: MiddlewareRoute[] = [
     matcher: '/vendor/invites/accept',
     method: ['POST'],
     middlewares: [
-      authenticate('vendor-admin', ['bearer', 'session'], {
+      authenticate('seller', ['bearer', 'session'], {
         allowUnregistered: true
       })
     ]
@@ -82,7 +82,7 @@ export const vendorMiddlewares: MiddlewareRoute[] = [
       ),
       unlessBaseUrl(
         /^\/vendor\/(sellers|invites\/accept)$/,
-        authenticate('vendor-admin', ['bearer', 'session'], {
+        authenticate('seller', ['bearer', 'session'], {
           allowUnregistered: false
         })
       ),

--- a/vendor-panel/src/hooks/api/auth.tsx
+++ b/vendor-panel/src/hooks/api/auth.tsx
@@ -14,7 +14,7 @@ export const useSignInWithEmailPass = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.login("vendor-admin", "emailpass", payload),
+    mutationFn: (payload) => sdk.auth.login("seller", "emailpass", payload),
     onSuccess: async (data, variables, context) => {
       options?.onSuccess?.(data, variables, context)
     },
@@ -33,7 +33,7 @@ export const useSignUpWithEmailPass = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.register("vendor-admin", "emailpass", payload),
+    mutationFn: (payload) => sdk.auth.register("seller", "emailpass", payload),
     onSuccess: async (_, variables) => {
       const seller = {
         name: variables.name,
@@ -60,7 +60,7 @@ export const useSignUpForInvite = (
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.register("vendor-admin", "emailpass", payload),
+    mutationFn: (payload) => sdk.auth.register("seller", "emailpass", payload),
     ...options,
   })
 }
@@ -70,7 +70,7 @@ export const useResetPasswordForEmailPass = (
 ) => {
   return useMutation({
     mutationFn: (payload) =>
-      sdk.auth.resetPassword("vendor-admin", "emailpass", {
+      sdk.auth.resetPassword("seller", "emailpass", {
         identifier: payload.email,
       }),
     onSuccess: async (data, variables, context) => {
@@ -93,7 +93,7 @@ export const useUpdateProviderForEmailPass = (
 ) => {
   return useMutation({
     mutationFn: (payload) =>
-      sdk.auth.updateProvider("vendor-admin", "emailpass", payload, token),
+      sdk.auth.updateProvider("seller", "emailpass", payload, token),
     onSuccess: async (data, variables, context) => {
       options?.onSuccess?.(data, variables, context)
     },


### PR DESCRIPTION
## Summary
- use seller auth domain for vendor panel login and registration
- authenticate vendor routes against seller tokens

## Testing
- `yarn test`
- `yarn test:unit --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bc7e6152a48331b65cef9263f1ef1c