### PR TITLE
feat(tenant): support additional tenant fields

### DIFF
--- a/backend/apps/backend/src/api/vendor/tenant/route.ts
+++ b/backend/apps/backend/src/api/vendor/tenant/route.ts
@@ -26,11 +26,21 @@ export const POST = async (
     throw new MedusaError(MedusaError.Types.NOT_FOUND, 'Tenant not found')
   }
 
-  const settings = { ...(tenant.settings || {}), ...req.validatedBody }
+  const { domain, logo, primary_color, secondary_color, store_name, store_description } =
+    req.validatedBody
 
-  const updated = await tenantService.updateTenants({
-    id: tenant.id,
-    settings
+  const settings = {
+    ...(tenant.settings || {}),
+    ...(store_name ? { store_name } : {}),
+    ...(store_description ? { store_description } : {}),
+  }
+
+  const updated = await tenantService.updateTenant(tenant.id, {
+    domain,
+    logo,
+    primary_color,
+    secondary_color,
+    settings,
   })
 
   res.json({ tenant: updated })

--- a/backend/apps/backend/src/api/vendor/tenant/validators.ts
+++ b/backend/apps/backend/src/api/vendor/tenant/validators.ts
@@ -6,6 +6,7 @@ export type VendorUpdateTenantSettingsType = z.infer<typeof VendorUpdateTenantSe
 
 export const VendorUpdateTenantSettings = z
   .object({
+    domain: z.string().optional(),
     logo: z.string().url().optional(),
     primary_color: z.string().regex(colorRegex).optional(),
     secondary_color: z.string().regex(colorRegex).optional(),

--- a/backend/apps/backend/src/shared/infra/http/middlewares/resolve-tenant.ts
+++ b/backend/apps/backend/src/shared/infra/http/middlewares/resolve-tenant.ts
@@ -25,7 +25,11 @@ export async function resolveTenant(
 
   try {
     const tenantService = req.scope.resolve<TenantModuleService>(TENANT_MODULE)
-    const [tenant] = await tenantService.listTenants({ slug })
+    let [tenant] = await tenantService.listTenants({ slug })
+
+    if (!tenant) {
+      ;[tenant] = await tenantService.listTenants({ domain: hostname })
+    }
 
     if (tenant) {
       ;(req as any).tenant = tenant

--- a/backend/packages/modules/tenant/src/migrations/Migration20250801000001.ts
+++ b/backend/packages/modules/tenant/src/migrations/Migration20250801000001.ts
@@ -1,0 +1,30 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20250801000001 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table if exists "tenant" add column if not exists "domain" text null, add column if not exists "primary_color" text null, add column if not exists "secondary_color" text null, add column if not exists "logo" text null;'
+    )
+    this.addSql(
+      'alter table if exists "tenant" add constraint "tenant_domain_unique" unique ("domain");'
+    )
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table if exists "tenant" drop constraint if exists "tenant_domain_unique";'
+    )
+    this.addSql(
+      'alter table if exists "tenant" drop column if exists "domain";'
+    )
+    this.addSql(
+      'alter table if exists "tenant" drop column if exists "primary_color";'
+    )
+    this.addSql(
+      'alter table if exists "tenant" drop column if exists "secondary_color";'
+    )
+    this.addSql(
+      'alter table if exists "tenant" drop column if exists "logo";'
+    )
+  }
+}

--- a/backend/packages/modules/tenant/src/models/tenant.ts
+++ b/backend/packages/modules/tenant/src/models/tenant.ts
@@ -3,5 +3,9 @@ import { model } from "@medusajs/framework/utils";
 export const Tenant = model.define("tenant", {
   id: model.id().primaryKey(),
   slug: model.text().unique(),
+  domain: model.text().unique().nullable(),
+  primary_color: model.text().nullable(),
+  secondary_color: model.text().nullable(),
+  logo: model.text().nullable(),
   settings: model.json().nullable(),
 });

--- a/backend/packages/modules/tenant/src/service.ts
+++ b/backend/packages/modules/tenant/src/service.ts
@@ -4,6 +4,19 @@ import { Tenant } from "./models/tenant";
 
 class TenantModuleService extends MedusaService({
   Tenant,
-}) {}
+}) {
+  async updateTenant(
+    id: string,
+    data: {
+      domain?: string
+      primary_color?: string
+      secondary_color?: string
+      logo?: string
+      settings?: Record<string, unknown>
+    }
+  ) {
+    return await this.updateTenants({ id, ...data })
+  }
+}
 
 export default TenantModuleService;

--- a/storefront/src/app/[locale]/(main)/layout.tsx
+++ b/storefront/src/app/[locale]/(main)/layout.tsx
@@ -19,7 +19,7 @@ export default async function RootLayout({
   const user = await retrieveCustomer()
   const regionCheck = await checkRegion(locale)
   const tenantData = tenant ? await retrieveTenant(tenant) : null
-  const logo = tenantData?.settings?.logo
+  const logo = tenantData?.logo
   const storeName = tenantData?.settings?.store_name
 
   if (!regionCheck) {

--- a/storefront/src/app/layout.tsx
+++ b/storefront/src/app/layout.tsx
@@ -33,8 +33,8 @@ export async function generateMetadata({
 
   const base = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
 
-  const icons = settings?.settings?.logo
-    ? [{ url: settings.settings.logo }]
+  const icons = settings?.logo
+    ? [{ url: settings.logo }]
     : undefined
 
   return {
@@ -66,8 +66,8 @@ export default async function RootLayout({
   const ALGOLIA_APP = process.env.NEXT_PUBLIC_ALGOLIA_ID
   const htmlLang = locale || "en"
 
-  const primary = tenantData?.settings?.primary_color
-  const secondary = tenantData?.settings?.secondary_color
+  const primary = tenantData?.primary_color
+  const secondary = tenantData?.secondary_color
 
   const style = primary || secondary
     ? `:root {${

--- a/storefront/src/lib/data/tenant.ts
+++ b/storefront/src/lib/data/tenant.ts
@@ -3,21 +3,22 @@
 import { sdk } from "../config"
 import { cache } from "react"
 
-export type TenantSettings = {
+export type Tenant = {
+  domain?: string
+  primary_color?: string
+  secondary_color?: string
+  logo?: string
   settings?: {
-    primary_color?: string
-    secondary_color?: string
-    logo?: string
     store_name?: string
     store_description?: string
   }
 }
 
-export const retrieveTenant = cache(async (slug: string): Promise<TenantSettings | null> => {
+export const retrieveTenant = cache(async (slug: string): Promise<Tenant | null> => {
   if (!slug) return null
 
   return sdk.client
-    .fetch<{ tenant: TenantSettings }>(`/store/tenant/${slug}`, {
+    .fetch<{ tenant: Tenant }>(`/store/tenant/${slug}`, {
       method: "GET",
       next: { revalidate: 60, tags: [`tenant-${slug}`] },
       cache: "force-cache",

--- a/vendor-panel/src/routes/settings/appearance/appearance-settings.tsx
+++ b/vendor-panel/src/routes/settings/appearance/appearance-settings.tsx
@@ -35,8 +35,8 @@ export const AppearanceSettings = () => {
   const form = useForm<z.infer<typeof AppearanceSchema>>({
     resolver: zodResolver(AppearanceSchema),
     defaultValues: {
-      primary_color: tenant?.settings?.primary_color || '#000000',
-      secondary_color: tenant?.settings?.secondary_color || '#000000',
+      primary_color: tenant?.primary_color || '#000000',
+      secondary_color: tenant?.secondary_color || '#000000',
       media: []
     }
   })
@@ -60,7 +60,7 @@ export const AppearanceSettings = () => {
     await mutateAsync({
       primary_color: values.primary_color,
       secondary_color: values.secondary_color,
-      logo: uploaded[0]?.url || tenant?.settings?.logo
+      logo: uploaded[0]?.url || tenant?.logo
     }, {
       onSuccess: () => toast.success(t('actions.save')),
       onError: (err) => toast.error(err.message)
@@ -74,7 +74,7 @@ export const AppearanceSettings = () => {
           <Form.Item>
             <Form.Label optional>Logo</Form.Label>
             <Form.Control>
-              <FileUpload uploadedImage={fields[0]?.url || tenant?.settings?.logo || ''} multiple={false} label={t('products.media.uploadImagesLabel')} hint={t('products.media.uploadImagesHint')} hasError={!!form.formState.errors.media} formats={SUPPORTED_FORMATS} onUploaded={onUploaded} />
+              <FileUpload uploadedImage={fields[0]?.url || tenant?.logo || ''} multiple={false} label={t('products.media.uploadImagesLabel')} hint={t('products.media.uploadImagesHint')} hasError={!!form.formState.errors.media} formats={SUPPORTED_FORMATS} onUploaded={onUploaded} />
             </Form.Control>
             <Form.ErrorMessage />
           </Form.Item>


### PR DESCRIPTION
## Summary
- extend tenant model with domain, colors, and logo fields
- expose new fields through tenant service and update API/Middleware
- adjust frontend apps to consume new tenant fields

## Testing
- `yarn lint` *(fails: 27 errors, 108 warnings)*
- `yarn lint` (storefront)
- `yarn lint` *(vendor-panel: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bc88ef808c8331b284b56baf049fa2