### PR TITLE
feat: add tenant scoping to core modules

### DIFF
--- a/backend/apps/backend/medusa-config.ts
+++ b/backend/apps/backend/medusa-config.ts
@@ -16,6 +16,9 @@ module.exports = defineConfig({
     }
   },
   modules: [
+    { resolve: './src/modules/product-tenant' },
+    { resolve: './src/modules/order-tenant' },
+    { resolve: './src/modules/customer-tenant' },
     { resolve: '@mercurjs/seller' },
     { resolve: '@mercurjs/reviews' },
     { resolve: '@mercurjs/marketplace' },

--- a/backend/apps/backend/src/modules/customer-tenant/index.ts
+++ b/backend/apps/backend/src/modules/customer-tenant/index.ts
@@ -1,0 +1,6 @@
+import { Module, Modules } from "@medusajs/framework/utils"
+import CustomerModuleService from "./service"
+
+export default Module(Modules.CUSTOMER, {
+  service: CustomerModuleService,
+})

--- a/backend/apps/backend/src/modules/customer-tenant/migrations/20250226000003-add-tenant-id.ts
+++ b/backend/apps/backend/src/modules/customer-tenant/migrations/20250226000003-add-tenant-id.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20250226000003 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('ALTER TABLE "customer" ADD COLUMN IF NOT EXISTS "tenant_id" text;')
+    this.addSql('CREATE INDEX IF NOT EXISTS "IDX_customer_tenant_id" ON "customer" (tenant_id);')
+    this.addSql('UPDATE "customer" SET "tenant_id" = (SELECT id FROM tenant LIMIT 1) WHERE tenant_id IS NULL;')
+  }
+
+  async down(): Promise<void> {
+    this.addSql('ALTER TABLE "customer" DROP COLUMN IF EXISTS "tenant_id";')
+  }
+}

--- a/backend/apps/backend/src/modules/customer-tenant/service.ts
+++ b/backend/apps/backend/src/modules/customer-tenant/service.ts
@@ -1,0 +1,5 @@
+import { withTenantScope } from "@mercurjs/framework"
+import { CustomerModuleService as MedusaCustomerModuleService } from "@medusajs/medusa/dist/modules/customer"
+
+const CustomerModuleService = withTenantScope(MedusaCustomerModuleService)
+export default CustomerModuleService

--- a/backend/apps/backend/src/modules/order-tenant/index.ts
+++ b/backend/apps/backend/src/modules/order-tenant/index.ts
@@ -1,0 +1,6 @@
+import { Module, Modules } from "@medusajs/framework/utils"
+import OrderModuleService from "./service"
+
+export default Module(Modules.ORDER, {
+  service: OrderModuleService,
+})

--- a/backend/apps/backend/src/modules/order-tenant/migrations/20250226000002-add-tenant-id.ts
+++ b/backend/apps/backend/src/modules/order-tenant/migrations/20250226000002-add-tenant-id.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20250226000002 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('ALTER TABLE "order" ADD COLUMN IF NOT EXISTS "tenant_id" text;')
+    this.addSql('CREATE INDEX IF NOT EXISTS "IDX_order_tenant_id" ON "order" (tenant_id);')
+    this.addSql('UPDATE "order" SET "tenant_id" = (SELECT id FROM tenant LIMIT 1) WHERE tenant_id IS NULL;')
+  }
+
+  async down(): Promise<void> {
+    this.addSql('ALTER TABLE "order" DROP COLUMN IF EXISTS "tenant_id";')
+  }
+}

--- a/backend/apps/backend/src/modules/order-tenant/service.ts
+++ b/backend/apps/backend/src/modules/order-tenant/service.ts
@@ -1,0 +1,5 @@
+import { withTenantScope } from "@mercurjs/framework"
+import { OrderModuleService as MedusaOrderModuleService } from "@medusajs/medusa/dist/modules/order"
+
+const OrderModuleService = withTenantScope(MedusaOrderModuleService)
+export default OrderModuleService

--- a/backend/apps/backend/src/modules/product-tenant/index.ts
+++ b/backend/apps/backend/src/modules/product-tenant/index.ts
@@ -1,0 +1,7 @@
+import { Module, Modules } from "@medusajs/framework/utils"
+
+import ProductModuleService from "./service"
+
+export default Module(Modules.PRODUCT, {
+  service: ProductModuleService,
+})

--- a/backend/apps/backend/src/modules/product-tenant/migrations/20250226000001-add-tenant-id.ts
+++ b/backend/apps/backend/src/modules/product-tenant/migrations/20250226000001-add-tenant-id.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@mikro-orm/migrations"
+
+export class Migration20250226000001 extends Migration {
+  async up(): Promise<void> {
+    this.addSql('ALTER TABLE "product" ADD COLUMN IF NOT EXISTS "tenant_id" text;')
+    this.addSql('CREATE INDEX IF NOT EXISTS "IDX_product_tenant_id" ON "product" (tenant_id);')
+    this.addSql('UPDATE "product" SET "tenant_id" = (SELECT id FROM tenant LIMIT 1) WHERE tenant_id IS NULL;')
+  }
+
+  async down(): Promise<void> {
+    this.addSql('ALTER TABLE "product" DROP COLUMN IF EXISTS "tenant_id";')
+  }
+}

--- a/backend/apps/backend/src/modules/product-tenant/service.ts
+++ b/backend/apps/backend/src/modules/product-tenant/service.ts
@@ -1,0 +1,5 @@
+import { withTenantScope } from "@mercurjs/framework"
+import { ProductModuleService as MedusaProductModuleService } from "@medusajs/product"
+
+const ProductModuleService = withTenantScope(MedusaProductModuleService)
+export default ProductModuleService


### PR DESCRIPTION
## Summary
- add tenant-aware wrappers for product, order, and customer services
- support tenant-scoped operations with reusable `withTenantScope` helper
- add migrations and config to persist tenant identifiers

## Testing
- `yarn lint` *(fails: Unexpected any... 27 errors, 108 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bad21b88331ae7fac2db8c1bb83