### PR TITLE
fix product service import

### DIFF
--- a/backend/apps/backend/src/modules/product-tenant/service.ts
+++ b/backend/apps/backend/src/modules/product-tenant/service.ts
@@ -1,5 +1,5 @@
 import { withTenantScope } from "@mercurjs/framework"
-import { ProductModuleService as MedusaProductModuleService } from "@medusajs/product"
+import MedusaProductModuleService from "@medusajs/product/dist/services/product-module-service"
 
 const ProductModuleService = withTenantScope(MedusaProductModuleService)
 export default ProductModuleService


### PR DESCRIPTION
## Summary
- fix product service import path for tenant scoping

## Testing
- `yarn lint` (fails: 27 errors)
- `yarn workspace api test:unit` (fails: No tests found, jest module naming collision)


------
https://chatgpt.com/codex/tasks/task_e_68bd2e078bbc8331aaed5750faa12c47