### PR TITLE
fix: register product module repositories

### DIFF
--- a/backend/apps/backend/src/modules/product-tenant/repositories/product-category.ts
+++ b/backend/apps/backend/src/modules/product-tenant/repositories/product-category.ts
@@ -1,0 +1,3 @@
+import ProductCategoryRepository from "@medusajs/product/dist/repositories/product-category"
+
+export default ProductCategoryRepository

--- a/backend/apps/backend/src/modules/product-tenant/repositories/product.ts
+++ b/backend/apps/backend/src/modules/product-tenant/repositories/product.ts
@@ -1,0 +1,3 @@
+import ProductRepository from "@medusajs/product/dist/repositories/product"
+
+export default ProductRepository


### PR DESCRIPTION
## Summary
- register product repositories for tenant-scoped product module

## Testing
- `yarn lint` *(fails: react-hooks/exhaustive-deps rule missing and other lint errors)*
- `yarn dev` *(fails: DB connection ECONNREFUSED, no productRepository resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3393faf883319245690d64f65021