### PR TITLE
fix: register product repository correctly

### DIFF
--- a/backend/apps/backend/src/modules/product-tenant/repositories/product-category.ts
+++ b/backend/apps/backend/src/modules/product-tenant/repositories/product-category.ts
@@ -1,3 +1,3 @@
-import ProductCategoryRepository from "@medusajs/product/dist/repositories/product-category"
+import { ProductCategoryRepository } from "@medusajs/product/dist/repositories/product-category"
 
 export default ProductCategoryRepository

--- a/backend/apps/backend/src/modules/product-tenant/repositories/product.ts
+++ b/backend/apps/backend/src/modules/product-tenant/repositories/product.ts
@@ -1,3 +1,3 @@
-import ProductRepository from "@medusajs/product/dist/repositories/product"
+import { ProductRepository } from "@medusajs/product/dist/repositories/product"
 
 export default ProductRepository


### PR DESCRIPTION
## Summary
- fix product tenant module to import `ProductRepository` and `ProductCategoryRepository` as named exports

## Testing
- `yarn lint` *(fails: 27 errors, 108 warnings)*
- `yarn test:unit` *(fails: Haste module naming collision; no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd3640f764833183c8ad9528c162dd