### PR TITLE
fix: configure seller module only once

### DIFF
--- a/backend/apps/backend/medusa-config.ts
+++ b/backend/apps/backend/medusa-config.ts
@@ -19,7 +19,6 @@ module.exports = defineConfig({
     { resolve: './src/modules/product-tenant' },
     { resolve: './src/modules/order-tenant' },
     { resolve: './src/modules/customer-tenant' },
-    { resolve: '@mercurjs/seller' },
     { resolve: '@mercurjs/reviews' },
     { resolve: '@mercurjs/marketplace' },
     { resolve: '@mercurjs/configuration' },
@@ -51,12 +50,12 @@ module.exports = defineConfig({
         appId: process.env.ALGOLIA_APP_ID
       }
     },
-{
-  resolve: "@mercurjs/seller",
-  options: {
-    emailpass: true   // enables email/password registration
-  }
-},
+    {
+      resolve: '@mercurjs/seller',
+      options: {
+        emailpass: true // enables email/password registration
+      }
+    },
 
     {
       resolve: '@medusajs/medusa/payment',


### PR DESCRIPTION
## Summary
- remove duplicate `@mercurjs/seller` module entry from medusa config
- enable email/password registration for seller module

## Testing
- `yarn lint` *(fails: unused variables, missing rules, etc.)*
- `yarn dev` *(fails: Pg connection failed to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_68bd384873e883319fb52289292a5773