### PR TITLE
refactor: fix link typings and tenant seed

### DIFF
--- a/backend/apps/backend/src/links/customer-review.ts
+++ b/backend/apps/backend/src/links/customer-review.ts
@@ -4,6 +4,7 @@ import CustomerModule from '@medusajs/medusa/customer'
 import ReviewModule from '@mercurjs/reviews'
 
 export default defineLink(CustomerModule.linkable.customer, {
-  linkable: ReviewModule.linkable.review,
+  // Cast as any as the module lacks typed linkables
+  linkable: (ReviewModule as any).linkable.review,
   isList: true
 })

--- a/backend/apps/backend/src/links/order-review.ts
+++ b/backend/apps/backend/src/links/order-review.ts
@@ -4,6 +4,7 @@ import OrderModule from '@medusajs/medusa/order'
 import ReviewModule from '@mercurjs/reviews'
 
 export default defineLink(OrderModule.linkable.order, {
-  linkable: ReviewModule.linkable.review,
+  // Cast to any for untyped linkable
+  linkable: (ReviewModule as any).linkable.review,
   isList: true
 })

--- a/backend/apps/backend/src/links/product-brand.ts
+++ b/backend/apps/backend/src/links/product-brand.ts
@@ -5,8 +5,8 @@ import BrandModule from '@mercurjs/brand'
 
 export default defineLink(
   {
-    linkable: ProductModule.linkable.product,
+    linkable: (ProductModule.linkable as any).product,
     isList: true
   },
-  BrandModule.linkable.brand
+  (BrandModule as any).linkable.brand
 )

--- a/backend/apps/backend/src/links/product-review.ts
+++ b/backend/apps/backend/src/links/product-review.ts
@@ -4,6 +4,6 @@ import ProductModule from '@medusajs/medusa/product'
 import ReviewModule from '@mercurjs/reviews'
 
 export default defineLink(ProductModule.linkable.product, {
-  linkable: ReviewModule.linkable.review,
+  linkable: (ReviewModule as any).linkable.review,
   isList: true
 })

--- a/backend/apps/backend/src/links/seller-request.ts
+++ b/backend/apps/backend/src/links/seller-request.ts
@@ -4,6 +4,6 @@ import RequestsModule from '@mercurjs/requests'
 import SellerModule from '@mercurjs/seller'
 
 export default defineLink(SellerModule.linkable.seller, {
-  linkable: RequestsModule.linkable.request,
+  linkable: (RequestsModule as any).linkable.request,
   isList: true
 })

--- a/backend/apps/backend/src/links/seller-review.ts
+++ b/backend/apps/backend/src/links/seller-review.ts
@@ -4,6 +4,6 @@ import ReviewModule from '@mercurjs/reviews'
 import SellerModule from '@mercurjs/seller'
 
 export default defineLink(SellerModule.linkable.seller, {
-  linkable: ReviewModule.linkable.review,
+  linkable: (ReviewModule as any).linkable.review,
   isList: true
 })

--- a/backend/apps/backend/src/scripts/seed/seed-functions.ts
+++ b/backend/apps/backend/src/scripts/seed/seed-functions.ts
@@ -22,7 +22,7 @@ import {
   ConfigurationRuleDefaults
 } from '@mercurjs/configuration'
 import { SELLER_MODULE } from '@mercurjs/seller'
-import { TENANT_MODULE } from '@mercurjs/tenant'
+import { TENANT_MODULE, TenantModuleService } from '@mercurjs/tenant'
 
 import sellerShippingProfile from '../../links/seller-shipping-profile'
 import { createCommissionRuleWorkflow } from '../../workflows/commission/workflows'
@@ -89,11 +89,14 @@ export async function createStore(
 }
 
 export async function createTenant(container: MedusaContainer) {
-  const tenantService = container.resolve(TENANT_MODULE)
+  const tenantService =
+    container.resolve<TenantModuleService>(TENANT_MODULE)
+
   const [tenant] = await tenantService.listTenants()
   if (tenant) {
     return tenant
   }
+
   const [created] = await tenantService.createTenants([
     { slug: 'default', settings: {} }
   ])

--- a/backend/apps/backend/src/workflows/attribute/utils/validate-attribute-values-to-link.ts
+++ b/backend/apps/backend/src/workflows/attribute/utils/validate-attribute-values-to-link.ts
@@ -1,5 +1,4 @@
 import {
-  InferTypeOf,
   MedusaContainer,
   ProductCategoryDTO,
   ProductDTO
@@ -10,8 +9,13 @@ import {
   MedusaErrorTypes
 } from '@medusajs/framework/utils'
 
-import Attribute from '@mercurjs/attribute/src/models/attribute'
 import { ProductAttributeValueDTO } from '@mercurjs/framework'
+
+type AttributeRecord = {
+  id: string
+  possible_values?: { value: string }[]
+  product_categories?: ProductCategoryDTO[]
+}
 
 export const validateAttributeValuesToLink = async ({
   attributeValues,
@@ -24,12 +28,7 @@ export const validateAttributeValuesToLink = async ({
 }) => {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  const attributeMap = new Map<
-    string,
-    InferTypeOf<typeof Attribute> & {
-      product_categories?: ProductCategoryDTO[]
-    }
-  >()
+  const attributeMap = new Map<string, AttributeRecord>()
 
   for (const attrVal of attributeValues) {
     const id = attrVal.attribute_id


### PR DESCRIPTION
## Summary
- fix untyped module link definitions
- remove direct Attribute import and add AttributeRecord type
- type tenantService in seed script

## Testing
- `npx turbo run build --filter=api`

------
https://chatgpt.com/codex/tasks/task_e_68bd3f90f9188331b876a4845aa54e1d