### PR TITLE
fix: enlarge mobile header logo

### DIFF
--- a/storefront/src/components/organisms/Header/Header.tsx
+++ b/storefront/src/components/organisms/Header/Header.tsx
@@ -57,8 +57,8 @@ export const Header = async () => {
               height={37}
               alt="Logo"
               priority
-              sizes="(max-width: 1024px) 110px, 135px"
-              className="w-[110px] h-[30px] lg:w-[135px] lg:h-[37px]"
+              sizes="135px"
+              className="w-[135px] h-[37px]"
             />
           </LocalizedClientLink>
         </div>


### PR DESCRIPTION
## Summary
- enlarge site logo in header for mobile to 135x37

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda8ef99388331ae60f0befbb58859