### PR TITLE
chore(storefront): adjust header logo size

### DIFF
--- a/storefront/src/components/organisms/Header/Header.tsx
+++ b/storefront/src/components/organisms/Header/Header.tsx
@@ -53,12 +53,12 @@ export const Header = async () => {
           <LocalizedClientLink href="/" className="text-2xl font-bold">
             <Image
               src="/Logo.svg"
-              width={135}
+              width={137}
               height={37}
               alt="Logo"
               priority
-              sizes="135px"
-              className="w-[135px] h-[37px]"
+              sizes="137px"
+              className="w-[137px] h-[37px]"
             />
           </LocalizedClientLink>
         </div>


### PR DESCRIPTION
## Summary
- adjust home page header logo to 137x37 dimensions

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdac7a312c8331b44cbd92e84f2ef5