### PR TITLE
fix: allow mobile scroll on product details

### DIFF
--- a/storefront/src/components/sections/ProductDetailsPage/ProductDetailsPage.tsx
+++ b/storefront/src/components/sections/ProductDetailsPage/ProductDetailsPage.tsx
@@ -27,7 +27,7 @@ export const ProductDetailsPage = async ({
         <div className="md:w-1/2 md:px-2">
           <ProductGallery images={prod?.images || []} />
         </div>
-        <div className="md:w-1/2 md:px-2">
+        <div className="md:w-1/2 md:px-2 max-md:h-[calc(100vh-350px)] max-md:overflow-y-auto">
           <ProductDetails product={prod} locale={locale} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- enable vertical scrolling for product details section on mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdb6c147508331bf4919a2c61bc423